### PR TITLE
fix: atcmd: wifi_api prototype parameter order

### DIFF
--- a/package/standalone/sdk/apps/atcmd/wifi_api.h
+++ b/package/standalone/sdk/apps/atcmd/wifi_api.h
@@ -164,7 +164,7 @@ extern int wifi_api_start_deep_sleep (uint32_t timeout, uint8_t gpio);
 extern bool wifi_api_wakeup_done (void);
 
 #ifdef CONFIG_ATCMD_SOFTAP
-extern int wifi_api_start_softap (int freq, int bw,
+extern int wifi_api_start_softap (int bw, int freq,
 								char *ssid, char *security, char *password,
 								int ssid_type, uint32_t timeout);
 extern int wifi_api_stop_softap (void);


### PR DESCRIPTION
Fix the header prototype for wifi_api_start_softap which has the bandwidth and frequency parameters swapped. The only caller for this function, atcmd_wifi, is passing the arguments in the correct order.

This change does not affect the binary, it's only a documentation fix.