### PR TITLE
  Fix compile errors for sample_tcp_server

### DIFF
--- a/package/standalone/lib/mbedtls/mbedtls/include/mbedtls/cmac.h
+++ b/package/standalone/lib/mbedtls/mbedtls/include/mbedtls/cmac.h
@@ -193,7 +193,7 @@ int mbedtls_cipher_cmac( const mbedtls_cipher_info_t *cipher_info,
  */
 int mbedtls_aes_cmac_prf_128( const unsigned char *key, size_t key_len,
                               const unsigned char *input, size_t in_len,
-                              unsigned char output[16] );
+                              unsigned char *output );
 #endif /* MBEDTLS_AES_C */
 
 #if defined(MBEDTLS_SELF_TEST) && ( defined(MBEDTLS_AES_C) || defined(MBEDTLS_DES_C) )

--- a/package/standalone/lib/mbedtls/mbedtls/library/ssl_tls.c
+++ b/package/standalone/lib/mbedtls/mbedtls/library/ssl_tls.c
@@ -1117,7 +1117,8 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 }
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3)
-void ssl_calc_verify_ssl( mbedtls_ssl_context *ssl, unsigned char hash[36] )
+// void ssl_calc_verify_ssl( mbedtls_ssl_context *ssl, unsigned char hash[36] )
+void ssl_calc_verify_ssl( mbedtls_ssl_context *ssl, unsigned char *hash )
 {
     mbedtls_md5_context md5;
     mbedtls_sha1_context sha1;
@@ -1166,7 +1167,7 @@ void ssl_calc_verify_ssl( mbedtls_ssl_context *ssl, unsigned char hash[36] )
 #endif /* MBEDTLS_SSL_PROTO_SSL3 */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1)
-void ssl_calc_verify_tls( mbedtls_ssl_context *ssl, unsigned char hash[36] )
+void ssl_calc_verify_tls( mbedtls_ssl_context *ssl, unsigned char *hash )
 {
     mbedtls_md5_context md5;
     mbedtls_sha1_context sha1;
@@ -1194,7 +1195,7 @@ void ssl_calc_verify_tls( mbedtls_ssl_context *ssl, unsigned char hash[36] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 #if defined(MBEDTLS_SHA256_C)
-void ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char hash[32] )
+void ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char *hash )
 {
     mbedtls_sha256_context sha256;
 
@@ -1215,7 +1216,7 @@ void ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char hash[32
 #endif /* MBEDTLS_SHA256_C */
 
 #if defined(MBEDTLS_SHA512_C)
-void ssl_calc_verify_tls_sha384( mbedtls_ssl_context *ssl, unsigned char hash[48] )
+void ssl_calc_verify_tls_sha384( mbedtls_ssl_context *ssl, unsigned char *hash)
 {
     mbedtls_sha512_context sha512;
 
@@ -6275,7 +6276,7 @@ static void ssl_calc_finished_tls_sha384(
     int len = 12;
     const char *sender;
     mbedtls_sha512_context sha512;
-    unsigned char padbuf[48];
+    unsigned char padbuf[64];
 
     mbedtls_ssl_session *session = ssl->session_negotiate;
     if( !session )

--- a/package/standalone/lib/nvs_flash/include/nvs_handle.hpp
+++ b/package/standalone/lib/nvs_flash/include/nvs_handle.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <type_traits>
+#include <cstddef>
 
 #include "nvs.h"
 

--- a/package/standalone/lib/nvs_flash/src/nvs_handle_simple.hpp
+++ b/package/standalone/lib/nvs_flash/src/nvs_handle_simple.hpp
@@ -14,6 +14,7 @@
 #ifndef NVS_HANDLE_SIMPLE_HPP_
 #define NVS_HANDLE_SIMPLE_HPP_
 
+#include <cstddef>
 #include "intrusive_list.h"
 #include "nvs_storage.hpp"
 #include "nvs_platform.hpp"


### PR DESCRIPTION
The mbedtls code has several places where the function definition and the declaration do not agree.

Moreover, the declaration is a pointer but the definition is an array.

These changes fix compile errors and have not been vetted.